### PR TITLE
Introduce RouletteTapWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+1 - 2022/11/2
+  * Document image reference fix
+  * Make `Roulette` a `StatelessWidget`
+
 ## 0.1.3 - 2022/10/21
 
 ### Behavior changes:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you want to map some list data into a uniformed `RouletteGroup`, try the buil
 final values = <int>[ /* Some value */ ];
 final group = RouletteGroup.uniform(
   values.length,
-  colorBuilder: Colors.blue,
+  colorBuilder: (_) => Colors.blue,
   textBuilder: (index) => (index + 1).toString(),
   textStyleBuilder: (index) {
     // Set the text style here!
@@ -56,6 +56,8 @@ controller = RouletteController(group: group, vsync: this);
 
 Once you have a controller, you could add a `Roulette` widget into your widget tree:
 
+#### Provide the controller directly
+
 ```dart
 @override
 Widget build(BuildContext context) {
@@ -64,6 +66,33 @@ Widget build(BuildContext context) {
     style: RouletteStyle(
       // config the roulette's appearance here
     ),
+  );
+}
+```
+
+#### Provide the controller under the tree with RouletteScope
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return RouletteScope(
+    controller: controller, // provide your controller here
+    child: const WidgetThatContainsRouletteDeeply(),
+  );
+}
+```
+
+and use the controller
+
+```dart
+@override
+Widget build(BuildContext context) {
+  final controller = RouletteScope.of(context)!;
+  return Roulette(
+    // Set this manually from the tree, 
+    // or just leave this empty to automatically 
+    // keep track to the nearest controller on the tree.
+    controller: controller,
   );
 }
 ```

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This is a library provide a simple roulette widget which usually used for lotter
 
   * Uniformed roulette:
 
-    <img alt="Uniformed with no text" src="README.assets/uniform_no_text.png" width="400">
+    <img alt="Uniformed with no text" src="https://raw.githubusercontent.com/do9core/roulette/main/README.assets/uniform_no_text.png" width="400">
 
   * Weight-based roulette:
 
-    <img alt="Weight based with text" src="README.assets/weight_based_with_text.png" width="400">
+    <img alt="Weight based with text" src="https://raw.githubusercontent.com/do9core/roulette/main/README.assets/weight_based_with_text.png" width="400">
 
 ## Getting started
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -42,15 +42,31 @@ class MyRoulette extends StatelessWidget {
           height: 260,
           child: Padding(
             padding: const EdgeInsets.only(top: 30),
-            child: Roulette(
-              // Provide controller to update its state
+            child: RouletteTapWrapper(
               controller: controller,
-              // Configure roulette's appearance
-              style: const RouletteStyle(
-                dividerThickness: 4,
-                textLayoutBias: .8,
-                centerStickerColor: Color(0xFF45A3FA),
-              ),
+              onTap: (index) {
+                showDialog(
+                  context: context,
+                  builder: (context) {
+                    return AlertDialog(
+                      title: const Text('Tap gesture detector'),
+                      content: Text('You have tapped part at $index'),
+                    );
+                  },
+                );
+              },
+              builder: (context, controller) {
+                return Roulette(
+                  // Provide controller to update its state
+                  controller: controller,
+                  // Configure roulette's appearance
+                  style: const RouletteStyle(
+                    dividerThickness: 4,
+                    textLayoutBias: .8,
+                    centerStickerColor: Color(0xFF45A3FA),
+                  ),
+                );
+              },
             ),
           ),
         ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -54,7 +54,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.1.3"
+    version: "0.1.3+1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/roulette.dart
+++ b/lib/roulette.dart
@@ -22,3 +22,4 @@ export './src/roulette_group.dart' show RouletteGroup;
 export './src/roulette_unit.dart' show RouletteUnit;
 export './src/roulette_style.dart' show RouletteStyle;
 export './src/tap_wrapper.dart' show RouletteTapWrapper;
+export './src/roulette_scope.dart' show RouletteScope;

--- a/lib/roulette.dart
+++ b/lib/roulette.dart
@@ -21,3 +21,4 @@ export './src/roulette_controller.dart' show RouletteController;
 export './src/roulette_group.dart' show RouletteGroup;
 export './src/roulette_unit.dart' show RouletteUnit;
 export './src/roulette_style.dart' show RouletteStyle;
+export './src/tap_wrapper.dart' show RouletteTapWrapper;

--- a/lib/src/roulette.dart
+++ b/lib/src/roulette.dart
@@ -14,6 +14,7 @@
 
 import 'package:flutter/material.dart';
 
+import 'roulette_scope.dart';
 import 'roulette_style.dart';
 import 'roulette_controller.dart';
 import 'roulette_paint.dart';
@@ -23,18 +24,26 @@ import 'roulette_paint.dart';
 class Roulette extends StatelessWidget {
   const Roulette({
     Key? key,
-    required this.controller,
+    this.controller,
     this.style = const RouletteStyle(),
   }) : super(key: key);
 
   /// Controls the roulette.
-  final RouletteController controller;
+  final RouletteController? controller;
 
   /// The display style of the roulette.
   final RouletteStyle style;
 
   @override
   Widget build(BuildContext context) {
+    final c = this.controller ?? RouletteScope.of(context);
+    assert(
+      c != null,
+      'no controller or scope controller of Roulette provided. '
+      'you should provide controller directly on Roulette widget or '
+      'specify it using RouletteScope',
+    );
+    final controller = c!;
     return AnimatedBuilder(
       animation: controller,
       builder: (context, child) {

--- a/lib/src/roulette.dart
+++ b/lib/src/roulette.dart
@@ -20,7 +20,7 @@ import 'roulette_paint.dart';
 
 /// This is an animatable roulette widget.
 /// You need to present a [RouletteController] to controll this widget.
-class Roulette extends StatefulWidget {
+class Roulette extends StatelessWidget {
   const Roulette({
     Key? key,
     required this.controller,
@@ -34,25 +34,17 @@ class Roulette extends StatefulWidget {
   final RouletteStyle style;
 
   @override
-  State<Roulette> createState() => _RouletteState();
-}
-
-class _RouletteState extends State<Roulette> {
-  @override
-  void initState() {
-    widget.controller.addListener(() {
-      setState(() {});
-    });
-    super.initState();
-  }
-
-  @override
   Widget build(BuildContext context) {
-    return RoulettePaint(
-      key: widget.key,
-      animation: widget.controller.animation,
-      style: widget.style,
-      group: widget.controller.group,
+    return AnimatedBuilder(
+      animation: controller,
+      builder: (context, child) {
+        return RoulettePaint(
+          key: key,
+          animation: controller.animation,
+          style: style,
+          group: controller.group,
+        );
+      },
     );
   }
 }

--- a/lib/src/roulette_scope.dart
+++ b/lib/src/roulette_scope.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:roulette/roulette.dart';
+
+class _RouletteScope extends InheritedWidget {
+  const _RouletteScope({
+    Key? key,
+    required this.controller,
+    required Widget child,
+  }) : super(key: key, child: child);
+
+  final RouletteController controller;
+
+  @override
+  bool updateShouldNotify(covariant _RouletteScope oldWidget) {
+    return !identical(oldWidget.controller, controller);
+  }
+}
+
+class RouletteScope extends StatelessWidget {
+  const RouletteScope({
+    Key? key,
+    required this.controller,
+    required this.child,
+  }) : super(key: key);
+
+  final RouletteController controller;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return _RouletteScope(
+      controller: controller,
+      child: child,
+    );
+  }
+
+  static RouletteController? of(BuildContext context) {
+    final scope = context.dependOnInheritedWidgetOfExactType<_RouletteScope>();
+    if (scope == null) return null;
+
+    return scope.controller;
+  }
+}

--- a/lib/src/tap_wrapper.dart
+++ b/lib/src/tap_wrapper.dart
@@ -1,0 +1,112 @@
+/// Copyright 2023 do9core
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+///    http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:roulette/roulette.dart';
+
+typedef RouletteBuilder = Widget Function(
+  BuildContext context,
+  RouletteController controller,
+);
+
+typedef RouletteTapCallback = void Function(int index);
+
+class RouletteTapWrapper extends StatefulWidget {
+  const RouletteTapWrapper({
+    Key? key,
+    required this.controller,
+    required this.builder,
+    this.onTap,
+  }) : super(key: key);
+
+  final RouletteController controller;
+  final RouletteTapCallback? onTap;
+  final RouletteBuilder builder;
+
+  @override
+  State<RouletteTapWrapper> createState() => _RouletteTapWrapperState();
+}
+
+class _RouletteTapWrapperState extends State<RouletteTapWrapper> {
+  final GlobalKey _rouletteKey = GlobalKey();
+  TapDownDetails? _lastTapDown;
+
+  @override
+  Widget build(BuildContext context) {
+    return Builder(
+      builder: (context) {
+        return GestureDetector(
+          onTapDown: widget.onTap == null ? null : (d) => _lastTapDown = d,
+          onTapUp: widget.onTap == null ? null : _handleTapUp,
+          onTapCancel: widget.onTap == null ? null : () => _lastTapDown = null,
+          child: SizedBox(
+            key: _rouletteKey,
+            child: widget.builder(context, widget.controller),
+          ),
+        );
+      },
+    );
+  }
+
+  void _handleTapUp(TapUpDetails details) {
+    final d = _lastTapDown;
+    if (d == null) return;
+    _lastTapDown = null;
+
+    final contentContext = _rouletteKey.currentContext;
+    if (contentContext == null) return;
+
+    final contentSize = (contentContext as Element).size;
+    if (contentSize == null) return;
+
+    final downPos = d.localPosition;
+    final center = Offset(contentSize.width / 2, contentSize.height / 2);
+    final offset = downPos - center;
+
+    double angle = 0;
+    final tan = offset.dy / offset.dx;
+    if (offset.dx > 0) {
+      angle = math.pi / 2 + math.atan(tan);
+    } else {
+      angle = math.pi / 2 * 3 + math.atan(tan);
+    }
+    // TODO: Check distance to center to prevent out of bound tap responding
+
+    // debugPrint('angle: $angle');
+
+    final divides = widget.controller.group.divide;
+    final single = 2 * math.pi / divides;
+    final rotation = widget.controller.animation.value;
+    final ranges = List.generate(
+      divides,
+      (index) {
+        final b1 = (single * index + rotation) % (2 * math.pi);
+        var b2 = (single * (index + 1) + rotation) % (2 * math.pi);
+        if (b2 == 0) b2 = 2 * math.pi;
+        return [math.min(b1, b2), math.max(b1, b2)];
+      },
+    );
+
+    // debugPrint('Stops: $ranges');
+    for (int i = 0; i < ranges.length; i++) {
+      final range = ranges[i];
+      if (angle >= range[0] && angle < range[1]) {
+        widget.onTap?.call(i);
+        break;
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: roulette
 description: This is a library provide a simple roulette widget which usually used for lottery.
-version: 0.1.3
+version: 0.1.3+1
 repository: https://github.com/do9core/roulette
 
 environment:


### PR DESCRIPTION
# Introduce `RouletteTapWrapper`.

Introduce the `RouletteTapWrapper` helper for responding user tap.

**!!!Disclaimer:**  

I'm not good at handling touch events, so this is not a fine-grained implementation, touch effect may not be very accuracy.

The proper way to implement this is add it to the `RoulettePaint`/`_RoulettePainter` class to make the painter Widget a implicit touchable Widget.

---

Closes #11