### PR TITLE
Prevent image tiling artifacts when rendering images

### DIFF
--- a/lib/src/roulette_paint.dart
+++ b/lib/src/roulette_paint.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:roulette/roulette.dart';
+import 'package:roulette/src/roulette_style.dart';
 import 'package:roulette/utils/transform_entry.dart';
 import 'package:roulette/utils/text.dart';
 
@@ -121,7 +122,7 @@ class _RoulettePainter extends CustomPainter {
     }
   }
 
-   /// Draws the image to the background of the current section.
+  /// Draws the image to the background of the current section.
   void _drawBackgroundImage(Canvas canvas, double radius, Rect rect,
       RouletteUnit unit, double sweep, ui.Image image) {
     // Draws the section background image
@@ -133,19 +134,45 @@ class _RoulettePainter extends CustomPainter {
 
     // Rectangle in which the section is.
     var rect2 = path.getBounds();
+    final Matrix4 matrix;
 
-    /*I added this to prevent images from being rendered with repeating patterns.
-    The image now occupies the intended area without being repeated. */
+    switch (style.sectionImageLayout) {
+      case SectionImageLayout.rotatedFit:
+        if (rect2.height > rect2.width) {
+          rect2 =
+              Rect.fromLTWH(rect2.left, rect2.top, rect2.height, rect2.height);
+        } else {
+          rect2 =
+              Rect.fromLTWH(rect2.left, rect2.top, rect2.width, rect2.width);
+        }
+        // Calculates size of image in the square.
+        double scaleX = (rect2.width / image.width);
+        double scaleY = (rect2.height / image.height);
 
-    // For use in the clean Matrix
-    double scaleX = rect2.width / image.width;
-    double scaleY = rect2.height / image.height;
-    double scale = max(scaleX, scaleY);
+        // Transformation matrix to scale and rotate image in the section.
+        matrix = composeMatrixFromOffsets(
+          translate: Offset(style.dividerThickness / 2 - 1,
+              rect2.top + rect2.height * 4 + style.dividerThickness / 2 + 1),
+          scale: (max(scaleX, scaleY)) - 0.002,
+          rotation: sweep / 2 + pi / 2,
+          anchor: Offset.zero,
+        );
+        break;
 
-    // Clean Matrix
-    final matrix = Matrix4.identity()
-    ..translateByDouble(rect2.left, rect2.top, 0.0, 1.0)
-    ..scaleByDouble(scale, scale, scale, 1);
+      case SectionImageLayout.boundingBoxFit:
+        // Prevent images from being rendered with repeating patterns.
+        // The image now occupies the intended area without being repeated.
+
+        // For use in the clean Matrix
+        double scaleX = rect2.width / image.width;
+        double scaleY = rect2.height / image.height;
+        double scale = max(scaleX, scaleY);
+
+        matrix = Matrix4.identity()
+          ..translateByDouble(rect2.left, rect2.top, 0.0, 1.0)
+          ..scaleByDouble(scale, scale, scale, 1);
+        break;
+    }
 
     // Drawing the TileMap
     canvas.drawPath(

--- a/lib/src/roulette_paint.dart
+++ b/lib/src/roulette_paint.dart
@@ -121,7 +121,7 @@ class _RoulettePainter extends CustomPainter {
     }
   }
 
-  /// Draws the image to the background of the current section.
+   /// Draws the image to the background of the current section.
   void _drawBackgroundImage(Canvas canvas, double radius, Rect rect,
       RouletteUnit unit, double sweep, ui.Image image) {
     // Draws the section background image
@@ -134,36 +134,29 @@ class _RoulettePainter extends CustomPainter {
     // Rectangle in which the section is.
     var rect2 = path.getBounds();
 
-    // Transforms into a square (biggest)
-    if (rect2.height > rect2.width) {
-      rect2 = Rect.fromLTWH(rect2.left, rect2.top, rect2.height, rect2.height);
-    } else {
-      rect2 = Rect.fromLTWH(rect2.left, rect2.top, rect2.width, rect2.width);
-    }
+    /*I added this to prevent images from being rendered with repeating patterns.
+    The image now occupies the intended area without being repeated. */
 
-    // Calculates size of image in the square.
-    double scaleX = (rect2.width / image.width);
-    double scaleY = (rect2.height / image.height);
+    // For use in the clean Matrix
+    double scaleX = rect2.width / image.width;
+    double scaleY = rect2.height / image.height;
+    double scale = max(scaleX, scaleY);
 
-    // Transformation matrix to scale and rotate image in the section.
-    Matrix4 matrix = composeMatrixFromOffsets(
-      translate: Offset(style.dividerThickness / 2 - 1,
-          rect2.top + rect2.height * 4 + style.dividerThickness / 2 + 1),
-      scale: (max(scaleX, scaleY)) - 0.002,
-      rotation: sweep / 2 + pi / 2,
-      anchor: Offset.zero,
-    );
+    // Clean Matrix
+    final matrix = Matrix4.identity()
+    ..translateByDouble(rect2.left, rect2.top, 0.0, 1.0)
+    ..scaleByDouble(scale, scale, scale, 1);
 
-    // Draws the section with the image.
+    // Drawing the TileMap
     canvas.drawPath(
       path,
       Paint()
         ..shader = ImageShader(
           image,
-          TileMode.repeated,
-          TileMode.repeated,
+          TileMode.clamp,
+          TileMode.clamp,
           matrix.storage,
-          filterQuality: FilterQuality.medium,
+          filterQuality: FilterQuality.high,
         )
         ..style = PaintingStyle.fill
         ..strokeWidth = 0,

--- a/lib/src/roulette_style.dart
+++ b/lib/src/roulette_style.dart
@@ -1,5 +1,27 @@
 import 'package:flutter/material.dart';
 
+import 'roulette_unit.dart';
+
+/// Determines how a background image is laid out within each roulette section.
+///
+/// When a [RouletteUnit] has an image set, this mode controls
+/// how the image is transformed and positioned inside the arc-shaped section.
+enum SectionImageLayout {
+  /// The image is rotated to align with the section's bisector angle,
+  /// then scaled to cover the section area.
+  ///
+  /// This produces a visually centered result where the image appears
+  /// to follow the section's orientation.
+  rotatedFit,
+
+  /// The image is scaled to fill the section's axis-aligned bounding box
+  /// without any rotation.
+  ///
+  /// This produces a simpler mapping where the image stretches to cover
+  /// the rectangular bounds of the section path.
+  boundingBoxFit,
+}
+
 /// Describe the render style of roulette.
 class RouletteStyle {
   /// Default section text style
@@ -22,6 +44,7 @@ class RouletteStyle {
     this.centerStickSizePercent = 0.1,
     this.textLayoutBias = 0.85,
     this.textStyle = defaultTextStyle,
+    this.sectionImageLayout = SectionImageLayout.rotatedFit,
   });
 
   /// The thickness of divider between each parts
@@ -41,4 +64,18 @@ class RouletteStyle {
 
   /// The text style of the [Roulette], can be override by the [RouletteUnit]'s textStyle.
   final TextStyle textStyle;
+
+  /// Controls how background images are rendered within each section.
+  ///
+  /// When a [RouletteUnit] specifies an image, this determines
+  /// the transformation applied to fit the image into the section's arc shape.
+  ///
+  /// Defaults to [SectionImageLayout.rotatedFit].
+  ///
+  /// See also:
+  ///  * [SectionImageLayout.rotatedFit], which rotates and scales the image
+  ///    to align with the section.
+  ///  * [SectionImageLayout.boundingBoxFit], which scales the image into the
+  ///    section's bounding rectangle without rotation.
+  final SectionImageLayout sectionImageLayout;
 }


### PR DESCRIPTION
This PR fixes an issue where images were rendered with visible tiling artifacts.
The change ensures the image is rendered only once and fits its intended bounds without repetition.

No functional behavior was changed beyond visual rendering.