### PR TITLE
Roulette sector tap support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.1 - 2026/3/9
+
+### New feature
+  * Add `TappableRoulette` widget with sector tap detection.
+
+### Others
+  * Add `device_preview_plus` to the example app.
+
 ## 0.3.0 - 2026/3/4
 
 ### New feature

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add this to your `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  roulette: ^0.3.0
+  roulette: ^0.3.1
 ```
 
 ## Usage
@@ -88,6 +88,26 @@ Widget build(BuildContext context) {
     controller: controller,
     style: RouletteStyle(
       // Customize appearance (e.g. sectionImageLayout for image sections)
+    ),
+  );
+}
+```
+
+### Add Tappable Roulette Widget
+
+Available from `0.3.1`, you can use `TappableRoulette` which wraps `Roulette` to detect which sector is tapped by the user.
+
+```dart
+@override
+Widget build(BuildContext context) {
+  return TappableRoulette(
+    group: group,
+    controller: controller,
+    onTap: (index) {
+      print('Tapped on $index sector');
+    },
+    style: RouletteStyle(
+      // Customize appearance
     ),
   );
 }

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -44,3 +44,11 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Example Platforms
+linux/
+macos/
+windows/
+android/
+ios/
+web/

--- a/example/.metadata
+++ b/example/.metadata
@@ -1,11 +1,11 @@
 # This file tracks properties of this Flutter project.
 # Used by Flutter tool to assess capabilities and perform upgrades etc.
 #
-# This file should be version controlled.
+# This file should be version controlled and should not be manually edited.
 
 version:
-  revision: 796c8ef79279f9c774545b3771238c3098dbefab
-  channel: stable
+  revision: "90673a4eef275d1a6692c26ac80d6d746d41a73a"
+  channel: "stable"
 
 project_type: app
 
@@ -13,11 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 796c8ef79279f9c774545b3771238c3098dbefab
-      base_revision: 796c8ef79279f9c774545b3771238c3098dbefab
-    - platform: linux
-      create_revision: 796c8ef79279f9c774545b3771238c3098dbefab
-      base_revision: 796c8ef79279f9c774545b3771238c3098dbefab
+      create_revision: 90673a4eef275d1a6692c26ac80d6d746d41a73a
+      base_revision: 90673a4eef275d1a6692c26ac80d6d746d41a73a
+    - platform: macos
+      create_revision: 90673a4eef275d1a6692c26ac80d6d746d41a73a
+      base_revision: 90673a4eef275d1a6692c26ac80d6d746d41a73a
 
   # User provided section
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,12 +1,17 @@
 import 'dart:math';
 
+import 'package:device_preview_plus/device_preview_plus.dart';
 import 'package:flutter/material.dart';
 
 import 'package:roulette/roulette.dart';
 import 'arrow.dart';
 
 void main() {
-  runApp(const MyApp());
+  runApp(
+    DevicePreview(
+      builder: (context) => const MyApp(),
+    ),
+  );
 }
 
 class MyApp extends StatelessWidget {
@@ -44,7 +49,8 @@ class MyRoulette extends StatelessWidget {
           height: 260,
           child: Padding(
             padding: const EdgeInsets.only(top: 30),
-            child: Roulette(
+            // Use Roulette if you don't need onTap callback
+            child: TappableRoulette(
               group: group,
               // Provide controller to update its state
               controller: controller,
@@ -55,11 +61,33 @@ class MyRoulette extends StatelessWidget {
                 centerStickSizePercent: 0.05,
                 centerStickerColor: Colors.black,
               ),
+              // Only available in TappableRoulette
+              onTap: (index) => showTappedSector(context, index),
             ),
           ),
         ),
         const Arrow(),
       ],
+    );
+  }
+
+  void showTappedSector(BuildContext context, int index) {
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Roulette'),
+          content: Text('You tapped $index sector'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+              child: Text('OK'),
+            )
+          ],
+        );
+      },
     );
   }
 }
@@ -79,6 +107,7 @@ class _HomePageState extends State<HomePage> {
   final _controller = RouletteController();
   bool _clockwise = true;
   AnimationMode _animationMode = AnimationMode.curve;
+  double _drag = 0.3;
 
   final colors = <Color>[
     Colors.red.withAlpha(50),
@@ -147,83 +176,125 @@ class _HomePageState extends State<HomePage> {
                 controller: _controller,
               ),
               const SizedBox(height: 40),
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  const Text(
-                    "Clockwise: ",
-                    style: TextStyle(fontSize: 18),
-                  ),
-                  Checkbox(
-                    value: _clockwise,
-                    onChanged: (onChanged) {
-                      setState(() {
-                        _controller.resetAnimation();
-                        _clockwise = !_clockwise;
-                      });
-                    },
-                  ),
-                ],
-              ),
-              SegmentedButton<AnimationMode>(
-                segments: const [
-                  ButtonSegment(
-                    value: AnimationMode.curve,
-                    label: Text('Curve'),
-                    icon: Icon(Icons.show_chart),
-                  ),
-                  ButtonSegment(
-                    value: AnimationMode.physics,
-                    label: Text('Physics'),
-                    icon: Icon(Icons.speed),
-                  ),
-                ],
-                selected: {_animationMode},
-                onSelectionChanged: (selected) {
-                  setState(() {
-                    _animationMode = selected.first;
-                  });
-                },
-              ),
-              const SizedBox(height: 8),
-              FilledButton(
-                onPressed: () async {
-                  final AnimationConfig config;
-                  switch (_animationMode) {
-                    case AnimationMode.curve:
-                      config = const CurveAnimationConfig(
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    spacing: 8,
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    children: [
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text(
+                            "Clockwise: ",
+                            style: TextStyle(fontSize: 18),
+                          ),
+                          Checkbox(
+                            value: _clockwise,
+                            onChanged: (onChanged) {
+                              setState(() {
+                                _controller.resetAnimation();
+                                _clockwise = !_clockwise;
+                              });
+                            },
+                          ),
+                        ],
+                      ),
+                      SegmentedButton<AnimationMode>(
+                        segments: const [
+                          ButtonSegment(
+                            value: AnimationMode.curve,
+                            label: Text('Curve'),
+                            icon: Icon(Icons.show_chart),
+                          ),
+                          ButtonSegment(
+                            value: AnimationMode.physics,
+                            label: Text('Physics'),
+                            icon: Icon(Icons.speed),
+                          ),
+                        ],
+                        selected: {_animationMode},
+                        onSelectionChanged: (selected) {
+                          setState(() {
+                            _animationMode = selected.first;
+                          });
+                        },
+                      ),
+                      AnimatedSize(
+                        duration: Durations.medium1,
                         curve: Curves.fastOutSlowIn,
-                        duration: Duration(seconds: 5),
-                      );
-                    case AnimationMode.physics:
-                      config = const PhysicsAnimationConfig(drag: 0.3);
-                  }
+                        child: _animationMode == AnimationMode.physics
+                            ? Row(
+                                key: ValueKey('physics'),
+                                children: [
+                                  Expanded(
+                                    child: Slider(
+                                      value: _drag,
+                                      min: 0.01,
+                                      max: 0.99,
+                                      onChanged: (value) {
+                                        setState(() {
+                                          _drag = value;
+                                        });
+                                      },
+                                    ),
+                                  ),
+                                  Text(_drag.toStringAsFixed(2)),
+                                ],
+                              )
+                            : SizedBox.shrink(key: ValueKey('curve')),
+                      ),
+                      const SizedBox(height: 8),
+                      FilledButton(
+                        onPressed: () async {
+                          final AnimationConfig config;
+                          switch (_animationMode) {
+                            case AnimationMode.curve:
+                              config = const CurveAnimationConfig(
+                                curve: Curves.fastOutSlowIn,
+                                duration: Duration(seconds: 5),
+                              );
+                            case AnimationMode.physics:
+                              config = PhysicsAnimationConfig(drag: _drag);
+                          }
 
-                  final completed = await _controller.rollTo(
-                    3,
-                    clockwise: _clockwise,
-                    offset: _random.nextDouble(),
-                    animationConfig: config,
-                  );
+                          final completed = await _controller.rollTo(
+                            3,
+                            clockwise: _clockwise,
+                            offset: _random.nextDouble(),
+                            animationConfig: config,
+                          );
 
-                  if (!context.mounted) return;
-                  if (completed) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Animation completed')),
-                    );
-                  } else {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Animation cancelled')),
-                    );
-                  }
-                },
-                child: const Text('ROLL'),
-              ),
-              FilledButton(
-                onPressed: () {
-                  _controller.stop();
-                },
-                child: const Text('CANCEL'),
+                          if (!context.mounted) return;
+                          if (completed) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                  content: Text('Animation completed')),
+                            );
+                          } else {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                  content: Text('Animation cancelled')),
+                            );
+                          }
+                        },
+                        child: const Text('ROLL'),
+                      ),
+                      FilledButton(
+                        onPressed: () {
+                          _controller.stop();
+                        },
+                        child: const Text('CANCEL'),
+                      ),
+                      FilledButton(
+                        onPressed: () {
+                          _controller.resetAnimation();
+                        },
+                        child: const Text('RESET'),
+                      ),
+                    ],
+                  ),
+                ),
               ),
             ],
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -17,6 +25,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  device_frame_plus:
+    dependency: transitive
+    description:
+      name: device_frame_plus
+      sha256: ccc94abccd4d9f0a9f19ef239001b3a59896e678ad42601371d7065889f2bf78
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
+  device_preview_plus:
+    dependency: "direct main"
+    description:
+      name: device_preview_plus
+      sha256: "29044c032d94932fc5c0e84a5791bf94c6c8918cce40cd7765e9bca5c9a5d136"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -30,6 +70,40 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
+  flutter_localizations:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: "7294967ff0a6d98638e7acb774aac3af2550777accd8149c90af5b014e6d44d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "805fa86df56383000f640384b282ce0cb8431f1a7a2396de92fb66186d8c57df"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.10.0"
   lints:
     dependency: transitive
     description:
@@ -54,6 +128,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.17.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  path:
+    dependency: transitive
+    description:
+      name: path
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.9.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5+1"
   roulette:
     dependency: "direct main"
     description:
@@ -61,6 +199,62 @@ packages:
       relative: true
     source: path
     version: "0.3.0"
+  shared_preferences:
+    dependency: transitive
+    description:
+      name: shared_preferences
+      sha256: "2939ae520c9024cb197fc20dee269cd8cdbf564c8b5746374ec6cacdc5169e64"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: "8374d6200ab33ac99031a852eba4c8eb2170c4bf20778b3e2c9eccb45384fb41"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.21"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "4e7eaffc2b17ba398759f1151415869a34771ba11ebbccd1b0145472a619a64f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -74,6 +268,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
-  flutter: ">=3.7.0"
+  dart: ">=3.9.2 <4.0.0"
+  flutter: ">=3.38.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
+  device_preview_plus: ^2.6.1
   flutter:
     sdk: flutter
 

--- a/lib/roulette.dart
+++ b/lib/roulette.dart
@@ -16,7 +16,7 @@
 /// @author do9core
 library roulette;
 
-export './src/roulette.dart' show Roulette;
+export './src/roulette.dart' show Roulette, TappableRoulette;
 export './src/roulette_controller.dart'
     show
         RouletteController,

--- a/lib/src/roulette.dart
+++ b/lib/src/roulette.dart
@@ -230,13 +230,18 @@ class RouletteState extends State<Roulette>
         return ValueListenableBuilder(
           valueListenable: rotateAnimation,
           builder: (context, Animation<double> animation, _) {
-            widget.onRotationChanged?.call(animation.value);
-            return RoulettePaint(
-              key: widget.key,
+            return AnimatedBuilder(
               animation: animation,
-              style: widget.style,
-              group: widget.group,
-              imageInfos: images,
+              builder: (context, child) {
+                widget.onRotationChanged?.call(animation.value);
+                return RoulettePaint(
+                  key: widget.key,
+                  rotation: animation.value,
+                  style: widget.style,
+                  group: widget.group,
+                  imageInfos: images,
+                );
+              },
             );
           },
         );

--- a/lib/src/roulette.dart
+++ b/lib/src/roulette.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'dart:math' as math;
 import 'dart:ui' as ui;
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:roulette/utils/helpers.dart';
 
@@ -14,11 +15,29 @@ import 'roulette_paint.dart';
 /// This is an animatable roulette widget.
 /// You need to present a [RouletteController] to control this widget.
 class Roulette extends StatefulWidget {
+  /// Creates a [Roulette] widget.
   const Roulette({
+    Key? key,
+    required RouletteGroup group,
+    required RouletteController controller,
+    RouletteStyle style = const RouletteStyle(),
+  }) : this._internal(
+          key: key,
+          group: group,
+          controller: controller,
+          style: style,
+        );
+
+  /// Internal constructor that accepts an [onRotationChanged] callback.
+  ///
+  /// This is used by [TappableRoulette] to observe the current rotation
+  /// angle without exposing rotation tracking on [RouletteController].
+  const Roulette._internal({
     Key? key,
     required this.group,
     required this.controller,
     this.style = const RouletteStyle(),
+    this.onRotationChanged,
   }) : super(key: key);
 
   /// Controls the roulette.
@@ -29,6 +48,10 @@ class Roulette extends StatefulWidget {
 
   /// The [RouletteGroup] to display.
   final RouletteGroup group;
+
+  /// Called on every frame with the current rotation angle in radians.
+  @internal
+  final ValueChanged<double>? onRotationChanged;
 
   @override
   State<Roulette> createState() => RouletteState();
@@ -207,6 +230,7 @@ class RouletteState extends State<Roulette>
         return ValueListenableBuilder(
           valueListenable: rotateAnimation,
           builder: (context, Animation<double> animation, _) {
+            widget.onRotationChanged?.call(animation.value);
             return RoulettePaint(
               key: widget.key,
               animation: animation,
@@ -258,4 +282,89 @@ ImageInfo _createErrorImage(Size size) {
       size.height.toInt(),
     ),
   );
+}
+
+/// A callback invoked when a sector of the roulette is tapped.
+///
+/// [index] is the 0-based index of the tapped [RouletteUnit] within the
+/// [RouletteGroup].
+typedef SectorTapCallback = void Function(int index);
+
+/// A tappable variant of [Roulette].
+///
+/// This widget wraps [Roulette] with hit-testing so that taps on the wheel
+/// report back which sector was tapped via [onTap]. The hit-test respects
+/// the current rotation of the wheel and variable sector sizes due to
+/// differing [RouletteUnit.weight] values.
+///
+/// Taps that land outside the wheel circle or inside the center sticker
+/// (controlled by [RouletteStyle.centerStickSizePercent]) are ignored.
+class TappableRoulette extends StatefulWidget {
+  const TappableRoulette({
+    Key? key,
+    required this.group,
+    required this.controller,
+    this.style = const RouletteStyle(),
+    this.onTap,
+  }) : super(key: key);
+
+  /// Controls the roulette animation.
+  final RouletteController controller;
+
+  /// The display style of the roulette.
+  final RouletteStyle style;
+
+  /// The [RouletteGroup] to display.
+  final RouletteGroup group;
+
+  /// Called when a sector is tapped. The callback receives the 0-based
+  /// index of the tapped sector.
+  final SectorTapCallback? onTap;
+
+  @override
+  State<TappableRoulette> createState() => _TappableRouletteState();
+}
+
+class _TappableRouletteState extends State<TappableRoulette> {
+  double _currentRotation = 0;
+
+  void _onRotationChanged(double rotation) {
+    _currentRotation = rotation;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // The Roulette uses AspectRatio(1.0), so width == height.
+        final size = Size(constraints.maxWidth, constraints.maxWidth);
+        return GestureDetector(
+          onTapUp: (details) => _handleTapUp(details, size),
+          child: Roulette._internal(
+            group: widget.group,
+            controller: widget.controller,
+            style: widget.style,
+            onRotationChanged: _onRotationChanged,
+          ),
+        );
+      },
+    );
+  }
+
+  void _handleTapUp(TapUpDetails details, Size size) {
+    final callback = widget.onTap;
+    if (callback == null) return;
+
+    final index = hitTestSector(
+      size: size,
+      group: widget.group,
+      rotation: _currentRotation,
+      localPosition: details.localPosition,
+      centerStickerPercent: widget.style.centerStickSizePercent,
+    );
+
+    if (index != null) {
+      callback(index);
+    }
+  }
 }

--- a/lib/src/roulette_paint.dart
+++ b/lib/src/roulette_paint.dart
@@ -10,21 +10,20 @@ import 'roulette_unit.dart';
 import '../utils/transform_entry.dart';
 import '../utils/text.dart';
 
-/// Animated roulette core by [AnimatedWidget]
-class RoulettePaint extends AnimatedWidget {
+/// Animated roulette core
+class RoulettePaint extends StatelessWidget {
   const RoulettePaint({
     Key? key,
-    required Animation<double> animation,
     required this.style,
     required this.group,
+    required this.rotation,
     required this.imageInfos,
-  }) : super(key: key, listenable: animation);
+  }) : super(key: key);
 
   final RouletteStyle style;
   final RouletteGroup group;
+  final double rotation;
   final Map<int, ImageInfo> imageInfos;
-
-  Animation<double> get _rotation => listenable as Animation<double>;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +31,7 @@ class RoulettePaint extends AnimatedWidget {
       aspectRatio: 1.0,
       child: CustomPaint(
         painter: _RoulettePainter(
-          rotate: _rotation.value,
+          rotate: rotation,
           style: style,
           group: group,
           imageInfos: imageInfos,

--- a/lib/utils/helpers.dart
+++ b/lib/utils/helpers.dart
@@ -81,6 +81,56 @@ class NormalizedFrictionSimulation extends Simulation {
   bool isDone(double time) => _inner.isDone(time);
 }
 
+/// Determines which sector of a roulette the given [localPosition] falls in.
+///
+/// [size] is the widget size (assumed square).
+/// [group] is the [RouletteGroup] whose weighted sectors to test against.
+/// [rotation] is the current rotation angle in radians applied to the wheel.
+/// [centerStickerPercent] is the radius fraction of the center sticker
+/// (taps inside this circle return `null`).
+///
+/// Returns the 0-based sector index, or `null` if the tap is outside the
+/// wheel circle or inside the center sticker.
+int? hitTestSector({
+  required Size size,
+  required RouletteGroup group,
+  required double rotation,
+  required Offset localPosition,
+  double centerStickerPercent = 0,
+}) {
+  final radius = size.width / 2;
+  final center = Offset(size.width / 2, size.height / 2);
+  final delta = localPosition - center;
+  final distance = delta.distance;
+
+  // Outside the circle.
+  if (distance > radius) return null;
+
+  // Inside the center sticker exclusion zone.
+  if (centerStickerPercent > 0 && distance < radius * centerStickerPercent) {
+    return null;
+  }
+
+  // The painter draws starting at angle -π/2 + rotation, so we reverse that
+  // to obtain the angle in "sector space".
+  final rawAngle = atan2(delta.dy, delta.dx);
+  // Subtract the base rotation (-π/2 + rotation) to get the sector-local angle.
+  var angle = rawAngle - (-pi / 2 + rotation);
+  // Normalize to [0, 2π).
+  angle = angle % (2 * pi);
+  if (angle < 0) angle += 2 * pi;
+
+  // Walk through sectors and find which one the angle falls in.
+  double cumulative = 0;
+  for (var i = 0; i < group.divide; i++) {
+    final sweep = 2 * pi * group.units[i].weight / group.totalWeights;
+    cumulative += sweep;
+    if (angle < cumulative) return i;
+  }
+  // Floating-point edge case – attribute to last sector.
+  return group.divide - 1;
+}
+
 typedef DoubleSelector<T> = double Function(T source);
 
 extension DoubleSum<T> on Iterable<T> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: roulette
 description: This is a library provide a simple roulette widget which usually used for lottery.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/do9core/roulette
 
 environment:

--- a/test/tappable_roulette_test.dart
+++ b/test/tappable_roulette_test.dart
@@ -1,0 +1,278 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:roulette/roulette.dart';
+import 'package:roulette/utils/helpers.dart';
+
+import 'test_component.dart';
+
+void main() {
+  group('hitTestSector', () {
+    const size = Size(400, 400); // radius = 200
+    const center = Offset(200, 200);
+
+    group('uniform sectors, no rotation', () {
+      // 4 uniform sectors, each 90°.
+      // Sector 0: 12 o'clock → 3 o'clock (drawn from -π/2 CW)
+      final group = RouletteGroup.uniform(4);
+
+      test('top-center (12 o\'clock direction) hits sector 0', () {
+        // Slightly above center — in the "up" direction.
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: Offset(center.dx, center.dy - 100),
+        );
+        expect(result, 0);
+      });
+
+      test('right-center (3 o\'clock direction) hits sector 1', () {
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: Offset(center.dx + 100, center.dy),
+        );
+        expect(result, 1);
+      });
+
+      test('bottom-center (6 o\'clock direction) hits sector 2', () {
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: Offset(center.dx, center.dy + 100),
+        );
+        expect(result, 2);
+      });
+
+      test('left-center (9 o\'clock direction) hits sector 3', () {
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: Offset(center.dx - 100, center.dy),
+        );
+        expect(result, 3);
+      });
+    });
+
+    group('uniform sectors, with rotation', () {
+      // 4 uniform sectors, rotate by π/2 (90° CW).
+      // After rotation the sector layout shifts: sector 0 now starts at
+      // angle 0 (3 o'clock) instead of -π/2 (12 o'clock).
+      final group = RouletteGroup.uniform(4);
+      const rotation = pi / 2; // 90° rotation
+
+      test('top-center hits the last sector after rotation', () {
+        // Up direction: the sector that used to cover "right→down" now covers
+        // "up" after 90° CW rotation, which is sector 3.
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: rotation,
+          localPosition: Offset(center.dx, center.dy - 100),
+        );
+        expect(result, 3);
+      });
+
+      test('right-center hits sector 0 after rotation', () {
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: rotation,
+          localPosition: Offset(center.dx + 100, center.dy),
+        );
+        expect(result, 0);
+      });
+    });
+
+    group('weighted sectors, no rotation', () {
+      // 3 sectors with weights [1, 2, 3] => total 6
+      // Sector 0: 60° (π/3)
+      // Sector 1: 120° (2π/3)
+      // Sector 2: 180° (π)
+      // Drawing starts at -π/2.
+      final group = RouletteGroup(const [
+        RouletteUnit(color: Colors.red, weight: 1),
+        RouletteUnit(color: Colors.green, weight: 2),
+        RouletteUnit(color: Colors.blue, weight: 3),
+      ]);
+
+      test('slightly right of top hits sector 0 (smallest)', () {
+        // 15° from top (well within the 60° sector 0)
+        final angle = -pi / 2 + pi / 12; // -π/2 + 15°
+        final pos = center + Offset(100 * cos(angle), 100 * sin(angle));
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: pos,
+        );
+        expect(result, 0);
+      });
+
+      test('90° from top hits sector 1 (medium)', () {
+        // 90° from start = -π/2 + π/2 = 0 → 3 o'clock.
+        // Sector 0 covers 0–60°, sector 1 covers 60°–180°.
+        // 90° is inside sector 1.
+        final angle = -pi / 2 + pi / 2; // 0 rad
+        final pos = center + Offset(100 * cos(angle), 100 * sin(angle));
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: pos,
+        );
+        expect(result, 1);
+      });
+
+      test('bottom-center hits sector 2 (largest)', () {
+        // 180° from start: inside the 180°-wide sector 2.
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: Offset(center.dx, center.dy + 100),
+        );
+        expect(result, 2);
+      });
+    });
+
+    group('boundary conditions', () {
+      final group = RouletteGroup.uniform(4);
+
+      test('outside circle returns null', () {
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: const Offset(0, 0), // corner, distance > radius
+        );
+        expect(result, isNull);
+      });
+
+      test('exactly at edge is still inside', () {
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: Offset(center.dx, 0), // exactly on top edge
+        );
+        expect(result, isNotNull);
+      });
+
+      test('center sticker exclusion returns null', () {
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: center, // exact center
+          centerStickerPercent: 0.1,
+        );
+        expect(result, isNull);
+      });
+
+      test('just outside center sticker returns a sector', () {
+        // Center sticker radius = 200 * 0.1 = 20.
+        // Place tap at 25px above center.
+        final result = hitTestSector(
+          size: size,
+          group: group,
+          rotation: 0,
+          localPosition: Offset(center.dx, center.dy - 25),
+          centerStickerPercent: 0.1,
+        );
+        expect(result, isNotNull);
+      });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────
+  // TappableRoulette widget tests
+  // ──────────────────────────────────────────────────────────────────
+  group('TappableRoulette', () {
+    testWidgets('tap calls onTap with correct sector index',
+        (WidgetTester tester) async {
+      await tester.configScreenSize(width: 400, height: 400);
+
+      final controller = RouletteController();
+      final group = RouletteGroup.uniform(4);
+      int? tappedIndex;
+
+      await tester.pumpWidget(
+        SizedBox(
+          width: 400,
+          height: 400,
+          child: TappableRoulette(
+            group: group,
+            controller: controller,
+            onTap: (index) => tappedIndex = index,
+          ),
+        ),
+      );
+
+      // Tap the top-center of the 400x400 widget → sector 0.
+      // Widget starts at (0,0) in a 400x400 surface.
+      await tester.tapAt(const Offset(200, 50));
+      await tester.pump();
+
+      expect(tappedIndex, 0);
+    });
+
+    testWidgets('tap outside circle does not trigger onTap',
+        (WidgetTester tester) async {
+      await tester.configScreenSize(width: 400, height: 400);
+
+      final controller = RouletteController();
+      final group = RouletteGroup.uniform(4);
+      int? tappedIndex;
+
+      await tester.pumpWidget(
+        SizedBox(
+          width: 400,
+          height: 400,
+          child: TappableRoulette(
+            group: group,
+            controller: controller,
+            onTap: (index) => tappedIndex = index,
+          ),
+        ),
+      );
+
+      // Tap top-left corner of the bounding box → outside the circle.
+      await tester.tapAt(const Offset(5, 5));
+      await tester.pump();
+
+      expect(tappedIndex, isNull);
+    });
+
+    testWidgets('tap on right side hits sector 1', (WidgetTester tester) async {
+      await tester.configScreenSize(width: 400, height: 400);
+
+      final controller = RouletteController();
+      final group = RouletteGroup.uniform(4);
+      int? tappedIndex;
+
+      await tester.pumpWidget(
+        SizedBox(
+          width: 400,
+          height: 400,
+          child: TappableRoulette(
+            group: group,
+            controller: controller,
+            onTap: (index) => tappedIndex = index,
+          ),
+        ),
+      );
+
+      // Tap right-center → sector 1.
+      await tester.tapAt(const Offset(350, 200));
+      await tester.pump();
+
+      expect(tappedIndex, 1);
+    });
+  });
+}


### PR DESCRIPTION
# Roulette sector tap support

## Description

This Merge Request introduces interactive functionality to the roulette wheel with a new `TappableRoulette` widget, allowing users to easily tap on a roulette sector and receive a callback with the tapped sector's index.

## Changes

### New Features
* **`TappableRoulette` Widget:** A new widget that wraps the existing `Roulette` to support tap interactions efficiently. 

### Refactoring
* Refactored `RoulettePaint` from `AnimatedWidget` to `StatelessWidget`.

### Examples & Tools
* Added `device_preview_plus` to the example application to better demonstrate how the widget looks and interacts across different device screen sizes.

## Checklist
- [x] Code compiles correctly
- [x] New tests have been added (unit tests for `hitTestSector` & widget tests for `TappableRoulette`)
- [x] All tests passing
- [x] CHANGELOG, README, and `pubspec.yaml` versions updated to `0.3.1`
- [x] Closes #11 